### PR TITLE
Fix flake8 errors

### DIFF
--- a/openfe_gromacs/protocols/gromacs_md/md_methods.py
+++ b/openfe_gromacs/protocols/gromacs_md/md_methods.py
@@ -25,11 +25,9 @@ import pint
 from gufe import ChemicalSystem, SmallMoleculeComponent, settings
 from openfe.protocols.openmm_utils import (
     charge_generation,
-    settings_validation,
     system_creation,
     system_validation,
 )
-from openfe.protocols.openmm_utils.omm_settings import BasePartialChargeSettings
 from openfe.utils import log_system_probe, without_oechem_backend
 from openff.interchange import Interchange
 from openff.toolkit.topology import Molecule as OFFMolecule

--- a/openfe_gromacs/tests/protocols/conftest.py
+++ b/openfe_gromacs/tests/protocols/conftest.py
@@ -9,8 +9,6 @@ from openff.units import unit
 from rdkit import Chem
 from rdkit.Geometry import Point3D
 
-import openfe_gromacs
-
 
 @pytest.fixture
 def benzene_vacuum_system(benzene_modifications):

--- a/openfe_gromacs/tests/protocols/test_gromacs_md.py
+++ b/openfe_gromacs/tests/protocols/test_gromacs_md.py
@@ -45,7 +45,8 @@ def test_serialize_protocol():
 
 def test_create_independent_repeat_ids(benzene_system):
     # if we create two dags each with 3 repeats, they should give 6 repeat_ids
-    # this allows multiple DAGs in flight for one Transformation that don't clash on gather
+    # this allows multiple DAGs in flight for one Transformation that don't
+    # clash on gather
     settings = GromacsMDProtocol.default_settings()
     # Default protocol is 1 repeat, change to 3 repeats
     settings.protocol_repeats = 3

--- a/openfe_gromacs/tests/protocols/test_md_settings.py
+++ b/openfe_gromacs/tests/protocols/test_md_settings.py
@@ -3,9 +3,7 @@
 import pytest
 from openff.units import unit
 
-from openfe_gromacs.protocols.gromacs_md.md_methods import (
-    GromacsMDProtocol,
-)
+from openfe_gromacs.protocols.gromacs_md.md_methods import GromacsMDProtocol
 
 
 def test_settings_pos_or_zero_error():

--- a/openfe_gromacs/tests/protocols/test_md_settings.py
+++ b/openfe_gromacs/tests/protocols/test_md_settings.py
@@ -1,18 +1,10 @@
 # This code is part of OpenFE and is licensed under the MIT license.
 # For details, see https://github.com/OpenFreeEnergy/openfe-gromacs
-import json
-import pathlib
-from unittest import mock
-
-import gufe
 import pytest
 from openff.units import unit
 
-import openfe_gromacs
 from openfe_gromacs.protocols.gromacs_md.md_methods import (
     GromacsMDProtocol,
-    GromacsMDProtocolResult,
-    GromacsMDSetupUnit,
 )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,9 @@ omit = [
 [tool.flake8]
 max-line-length = 88
 extend-ignore = ['E203',]
+per-file-ignores = [
+    '__init__.py:F401',
+]
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,12 @@ extend-ignore = ['E203',]
 per-file-ignores = [
     '__init__.py:F401',
 ]
+builtins = [
+    "nanometer",
+    "picosecond",
+    "kelvin",
+    "bar",
+]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Some notes:

1. I just removed the unused imports that it was complaining about 
1. I fixed the line that was too long by breaking the comment into two lines
1. I told flake8 to ignore F401 (unused import) on `__init__.py` files (you can avoid this by using the `__all__ = [foo, bar,]` dunder but since we don't really export any api in the `__init__.py` that we would want to not pull in with a `*` import I opted to just ignore those checks on all `__init__.py` files)
1. I added the units it was complaining about to the "builtins" list -- I don't think there is a cleaner way of doing this in flake8. I am not sure how `Literal[..]` works but flake8 does something to make it work, we may be able to get `FloatQuanity` to do some magic to make it work the same.


We should make this a required check since when pre-commit fails we either need to fix the errors or tell pre-commit to ignore the error if it is a false positive.

If things have settled enough, all the CI, docs, and pre-commit.ci should be required IMHO