### PR TITLE
Remove unused gmxapi install

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -64,13 +64,6 @@ jobs:
             python=${{ matrix.python-version }}
           init-shell: bash
 
-      - name: Install gmxapi
-        run: |
-          # gmxapi needs to be pointed to where gromacs lives
-          # we also need to tell it where to find our compilers
-          export CMAKE_ARGS="-Dgmxapi_ROOT=$CONDA_PREFIX -C $CONDA_PREFIX/share/cmake/gromacs/gromacs-hints.cmake -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC"
-          pip install gmxapi
-
       - name: Install package
         run: python -m pip install . --no-deps
 


### PR DESCRIPTION
## Description
Removes the `gmxapi` from the CI installs since the `gmxapi` is currently not used in this package.