### PR TITLE
temp pin openfe and update CI

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -39,7 +39,7 @@ jobs:
         # We don't really support windows so we don't need
         # to test it
         os: ["ubuntu-latest"]
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12"]
         include:
           - os: "macos-latest"
             python-version: "3.12"

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: "CI"
 
 on:
   push:
@@ -38,8 +38,11 @@ jobs:
       matrix:
         # We don't really support windows so we don't need
         # to test it
-        os: [macOS-latest, ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        os: ["ubuntu-latest"]
+        python-version: ["3.11", "3.12", "3.13"]
+        include:
+          - os: "macos-latest"
+            python-version: "3.12"
 
     steps:
       - uses: actions/checkout@v4

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge/label/openff-interchange_rc
   - conda-forge
 dependencies:
-  - openfe
+  - openfe == 1.6.1
   - compilers
   - mpi4py
   - gromacs

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge/label/openff-interchange_rc
   - conda-forge
 dependencies:
-  - openfe == 1.6.1
+  - openfe ==1.6.1  # until https://github.com/OpenFreeEnergy/openfe-gromacs/issues/83 is resolved
   - compilers
   - mpi4py
   - gromacs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 # Declare any run-time dependencies that should be installed with the package.
 #dependencies = [
 #    "importlib-resources;python_version<'3.10'",


### PR DESCRIPTION
## Description
until we get to https://github.com/OpenFreeEnergy/openfe-gromacs/issues/83

I'm also bumping our python range to 3.11-3.13 to be consistent with the rest of the ecosystem (plus, 3.10 was failing due to upstream deps)

Update: python 3.13 work tracked here: https://github.com/OpenFreeEnergy/openfe-gromacs/issues/85